### PR TITLE
Enabling configuration via environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@ services:
   app:
     build: .
     ports:
-     - "12345:80"
+     - "8081:8081"
   mongo:
     image: "mongo"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Contents:
 
    userguide
    events
+   runbook
 
 
 

--- a/docs/runbook.rst
+++ b/docs/runbook.rst
@@ -1,0 +1,19 @@
+Tycho Runbook
+=============
+
+Simplest to Try: Docker-Compose
+*********************************
+
+Using docker-compose, you can bring up a tycho service and a mongo database
+to try tycho out.
+
+A Production Deployment
+***********************
+
+Tycho requires a `mongodb <https://www.mongodb.com/>`_ instance to run. Once a
+mongo server is up, you can connect the Tycho docker container to it by passing the URI
+as the environment variable TYCHO_MONGODB_URI::
+
+  docker run -e "TYCHO_MONGODB_URI=mongodb://localhost:27017" --network=host tycho:latest
+
+Tycho will always use the database name "tycho", and serves at port 8081

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -9,4 +9,4 @@ max_requests = 10000
 # adequate jitter between worker restarts.
 max_requests_jitter = 5000
 worker_class = "aiohttp.worker.GunicornWebWorker"
-bind = "0.0.0.0:80"
+bind = "0.0.0.0:8081"

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ DB_URI = os.environ.get(
     "mongodb://mongo:27017/?maxPoolSize=1&w=1"
 )
 
-print(DB_URI)
 
 config = Config({
     "mongo": {

--- a/main.py
+++ b/main.py
@@ -1,16 +1,21 @@
 import asyncio
+import os
 from tycho.app import create_app
 from tycho.models.config import Config
 
+DB_URI = os.environ.get(
+    "TYCHO_MONGODB_URI",
+    "mongodb://mongo:27017/?maxPoolSize=1&w=1"
+)
+
+print(DB_URI)
+
 config = Config({
     "mongo": {
+        "uri": DB_URI,
         "db_name": "tycho",
-        "hosts": "mongo:27017",
-        "max_pool_size": 1,
-        "write_concern": 1
     },
 })
 
-
 loop = asyncio.get_event_loop()
-app = loop.run_until_complete(create_app(loop, config))
+app = create_app(config)

--- a/tycho/db/connection.py
+++ b/tycho/db/connection.py
@@ -22,11 +22,12 @@ def get_db(db_config):
     creates connection with dabatase and gets db object to connect.
     """
     connection = motor.motor_asyncio.AsyncIOMotorClient(
-        host=db_config.hosts,
-        replicaset=db_config.replicaset,
-        maxPoolSize=db_config.max_pool_size,
+        host=db_config.uri,
+        # secondarypreferred has proved to be a good practice,
+        # as it enabled minimal contention on the node that should
+        # be critical and handle writes. Oftentimes delay of event
+        # propagation is in the milliseconds.
         readPreference="secondaryPreferred",
-        w=db_config.write_concern
     )
     db = connection[db_config.db_name]
     return db

--- a/tycho/models/config.py
+++ b/tycho/models/config.py
@@ -4,11 +4,8 @@ from schematics.types.compound import ModelType
 
 
 class Mongo(Model):
-    hosts = StringType(required=True)
-    replicaset = StringType(required=True)
+    uri = StringType(required=True)
     db_name = StringType(required=True)
-    max_pool_size = StringType(required=True)
-    write_concern = StringType(required=True)
 
 
 class application(Model):

--- a/tycho/tests/conftest.py
+++ b/tycho/tests/conftest.py
@@ -19,7 +19,7 @@ global_source_id = "222f1f77bcf86cd799439011"
 DB_NAME = "tycho-tests-{}".format(os.getpid())
 
 DB_CONFIG = Mongo({
-    "uri": f"mongodb://localhost:27017/?maxPoolSize=10&w=1",
+    "uri": "mongodb://localhost:27017/?maxPoolSize=10&w=1",
     "db_name": DB_NAME,
 })
 

--- a/tycho/tests/conftest.py
+++ b/tycho/tests/conftest.py
@@ -19,10 +19,8 @@ global_source_id = "222f1f77bcf86cd799439011"
 DB_NAME = "tycho-tests-{}".format(os.getpid())
 
 DB_CONFIG = Mongo({
-        "db_name": DB_NAME,
-        "hosts": ",".join(["localhost:27017"]),
-        "max_pool_size": 10,
-        "write_concern": 1
+    "uri": f"mongodb://localhost:27017/?maxPoolSize=10&w=1",
+    "db_name": DB_NAME,
 })
 
 
@@ -51,19 +49,15 @@ def app(loop, config, db):
 @pytest.yield_fixture
 def db(loop, config):
     asyncio.set_event_loop(loop)
-    DB_NAME = config.mongo.db_name
-    if DB_NAME is "ets-monitor_live":
-        raise Exception("ets-monitor_live should not be used for unit testing")
     _db = init_db(config.mongo)
-
     yield _db
     if _db:
         loop.run_until_complete(_db.command("dropDatabase"))
 
 
 @pytest.fixture
-def cli(loop, test_client, config, app):
-    return loop.run_until_complete(test_client(app))
+def cli(loop, aiohttp_client, config, app):
+    return loop.run_until_complete(aiohttp_client(app))
 
 
 @pytest.fixture


### PR DESCRIPTION
Exposing a way to configure the MongoDB connection URI via an
environment variable. This simplifies setup for the majority of
use cases, who simply would like to start a docker container and
pass in appropriate environment variables.

Internally tycho utilizes a config object, but exposing the existing
values would have severely limited the options available to configure
the MongoDB configuration.

Updating documentation to include instructions on how to bring up a
service against a non-local mongo.