### PR TITLE
 adding a configuration parameter for logging events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='tycho',
           'aiohttp-transmute',
           'motor',
           'pymongo',
-          'orbital-core'
+          'orbital-core',
       ],
       entry_points={
           'console_scripts': [

--- a/tycho/app.py
+++ b/tycho/app.py
@@ -6,6 +6,7 @@ from .routes import add_routes
 from .db import init_db as init_db
 from orbital_core import bootstrap_app
 
+
 APP_ROOT = os.path.dirname(__file__)
 
 

--- a/tycho/models/config.py
+++ b/tycho/models/config.py
@@ -1,5 +1,5 @@
 from schematics.models import Model
-from schematics.types import StringType, IntType
+from schematics.types import StringType, IntType, BooleanType
 from schematics.types.compound import ModelType
 
 
@@ -18,3 +18,6 @@ class Config(Model):
     environment = StringType(required=False)
     mongo = ModelType(Mongo, required=True)
     application = ModelType(application, required=True)
+    # a configuration parameter to define whether events should be
+    # logged any time an event is added/updated
+    log_events = BooleanType(required=False, default=True)

--- a/tycho/routes/event.py
+++ b/tycho/routes/event.py
@@ -140,7 +140,8 @@ async def put_event(request, event: Event) -> Event:
     :return: the stored event
     """
     await request.app["db"].event.save(event)
-    LOG.info(event.to_primitive())
+    if request.app["config"].log_events:
+        LOG.info(event.to_primitive())
     return event
 
 
@@ -182,9 +183,11 @@ async def post_event(request, event: Event,
             _merge(existing_event, event)
         else:
             _update(existing_event, event)
-        LOG.info(event.to_primitive())
     except HTTPNotFound:
         existing_event = event
+
+    if request.app["config"].log_events:
+        LOG.info(event.to_primitive())
     await request.app["db"].event.update_by_id(event.id, existing_event, insert)
     return existing_event
 

--- a/tycho/routes/event.py
+++ b/tycho/routes/event.py
@@ -2,7 +2,7 @@ import aiohttp_transmute
 import attr
 import json
 import os
-
+import logging
 from aiohttp import web
 from aiohttp.web import HTTPNotFound
 from aiohttp_transmute import (APIException, add_route, route)
@@ -12,6 +12,9 @@ from ..models.events_with_count import EventListWithCount
 from ..models.event import Event
 
 from ..templates import get_template
+
+
+LOG = logging.getLogger(__name__)
 
 
 @aiohttp_transmute.describe(methods="GET", paths="/api/v1/event/{event_id}")
@@ -137,6 +140,7 @@ async def put_event(request, event: Event) -> Event:
     :return: the stored event
     """
     await request.app["db"].event.save(event)
+    LOG.info(event.to_primitive())
     return event
 
 
@@ -178,6 +182,7 @@ async def post_event(request, event: Event,
             _merge(existing_event, event)
         else:
             _update(existing_event, event)
+        LOG.info(event.to_primitive())
     except HTTPNotFound:
         existing_event = event
     await request.app["db"].event.update_by_id(event.id, existing_event, insert)


### PR DESCRIPTION
There are cases where we might want to log events whenever they are added/updated to Tycho.
This commit adds a configuration option that logs events by default, but can be overriden to not log updates

@toumorokoshi 