### PR TITLE
Added retry on DuplicateKeyError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(name='tycho',
           'motor',
           'pymongo',
           'orbital-core',
-          "asynctest",
       ],
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='tycho',
           'motor',
           'pymongo',
           'orbital-core',
+          "asynctest",
       ],
       entry_points={
           'console_scripts': [

--- a/tycho/db/event/__init__.py
+++ b/tycho/db/event/__init__.py
@@ -4,7 +4,6 @@ import queue as q
 
 from pymongo.errors import DuplicateKeyError
 from aiohttp.web import HTTPNotFound
-from transmute_core import APIException
 
 from ..utils import async_generator
 from ...models.eventnode import EventNode

--- a/tycho/db/event/__init__.py
+++ b/tycho/db/event/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import pymongo
 import queue as q
+import random
 
 from pymongo.errors import DuplicateKeyError
 from aiohttp.web import HTTPNotFound
@@ -13,7 +14,7 @@ from .serialize import serialize_to_db_event
 
 
 MAX_RECURSIVE_DEPTH = 100
-WAIT_TIME_SECONDS = 1
+MAX_WAIT_TIME_SECONDS = 5
 
 
 class Event:
@@ -52,11 +53,11 @@ class Event:
         retries = 1
         while retries >= 0:
             try:
-                result = await self.collection.replace_one(
+                result = await self.collection.find_one_and_replace(
                     {"_id": id}, new_data, upsert=insert)
                 return result
             except DuplicateKeyError:
-                await asyncio.sleep(WAIT_TIME_SECONDS)
+                await asyncio.sleep(random.randint(1, MAX_WAIT_TIME_SECONDS))
                 retries -= 1
                 if retries < 0:
                     raise

--- a/tycho/db/event/__init__.py
+++ b/tycho/db/event/__init__.py
@@ -14,7 +14,7 @@ from .serialize import serialize_to_db_event
 
 
 MAX_RECURSIVE_DEPTH = 100
-MAX_WAIT_TIME_SECONDS = 5
+MAX_WAIT_TIME_SECONDS = 0.5
 
 
 class Event:
@@ -57,7 +57,7 @@ class Event:
                     {"_id": id}, new_data, upsert=insert)
                 return result
             except DuplicateKeyError:
-                await asyncio.sleep(random.randint(1, MAX_WAIT_TIME_SECONDS))
+                await asyncio.sleep(random.uniform(0.0, MAX_WAIT_TIME_SECONDS))
                 retries -= 1
                 if retries < 0:
                     raise

--- a/tycho/db/event/__init__.py
+++ b/tycho/db/event/__init__.py
@@ -14,7 +14,7 @@ from .serialize import serialize_to_db_event
 
 
 MAX_RECURSIVE_DEPTH = 100
-WAIT_TIME_S = 1
+WAIT_TIME_SECONDS = 1
 
 
 class Event:
@@ -57,7 +57,7 @@ class Event:
                     {"_id": id}, new_data, upsert=insert)
                 return result
             except DuplicateKeyError:
-                await asyncio.sleep(WAIT_TIME_S)
+                await asyncio.sleep(WAIT_TIME_SECONDS)
                 retries -= 1
                 if retries < 0:
                     raise

--- a/tycho/tests/db/event/test_event__init__.py
+++ b/tycho/tests/db/event/test_event__init__.py
@@ -6,7 +6,6 @@ from asynctest import CoroutineMock, patch
 from copy import deepcopy
 from datetime import datetime, timedelta
 from pymongo.errors import DuplicateKeyError
-from transmute_core import APIException
 from tycho.models.event import Event
 from tycho.db.event import MAX_RECURSIVE_DEPTH
 

--- a/tycho/tests/db/event/test_event__init__.py
+++ b/tycho/tests/db/event/test_event__init__.py
@@ -100,14 +100,16 @@ async def test_update_by_id_on_nothing(app, event):
 
 
 async def test_update_by_id_pymongo_raises_duplicate_key_error_successful_on_retry(app, event):
-    with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
+    with patch.object(app["db"].event.collection, "find_one_and_replace", new=CoroutineMock())\
+            as mock_replace:
         mock_replace.side_effect = [DuplicateKeyError("error_msg"), 1]
 
         await app["db"].event.update_by_id(event.id, event)
 
 
 async def test_update_by_id_pymongo_raises_duplicate_key_error_failure_on_retry(app, event):
-    with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
+    with patch.object(app["db"].event.collection, "find_one_and_replace", new=CoroutineMock())\
+            as mock_replace:
         mock_replace.side_effect = [DuplicateKeyError("error after first run"),
                                     DuplicateKeyError("error after second run")]
 

--- a/tycho/tests/db/event/test_event__init__.py
+++ b/tycho/tests/db/event/test_event__init__.py
@@ -1,9 +1,13 @@
 import pytest
 import attr
+
 from aiohttp.web import HTTPNotFound
-from datetime import datetime, timedelta
-from tycho.models.event import Event
+from asynctest import CoroutineMock, patch
 from copy import deepcopy
+from datetime import datetime, timedelta
+from pymongo.errors import DuplicateKeyError
+from transmute_core import APIException
+from tycho.models.event import Event
 from tycho.db.event import MAX_RECURSIVE_DEPTH
 
 
@@ -94,6 +98,32 @@ async def test_update_by_id_on_nothing(app, event):
     await app["db"].event.update_by_id(event.id, event)
     with pytest.raises(HTTPNotFound):
         result = await app["db"].event.find_by_id(event.id)
+
+
+async def test_update_by_id_pymongo_raises_duplicate_key_error_successful_on_retry(app, event):
+    with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
+        mock_replace.side_effect = [DuplicateKeyError("error_msg"), 1]
+
+        await app["db"].event.update_by_id(event.id, event)
+
+
+async def test_update_by_id_pymongo_raises_duplicate_key_error_failure_on_retry(app, event):
+    with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
+        mock_replace.side_effect = DuplicateKeyError("error_msg")
+
+        with pytest.raises(APIException,
+                           match=f"Failed to update event data for event_id {event.id}"
+                                 f" due to DuplicateKeyError: error_msg"):
+            await app["db"].event.update_by_id(event.id, event)
+
+
+async def test_update_by_id_pymongo_raises_exception(app, event):
+    with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
+        mock_replace.side_effect = Exception("error_msg")
+
+        with pytest.raises(APIException,
+                           match=f"Failed to update event data for event_id {event.id}: error_msg"):
+            await app["db"].event.update_by_id(event.id, event)
 
 
 async def test_find_by_parent_id(app, event):

--- a/tycho/tests/db/event/test_event__init__.py
+++ b/tycho/tests/db/event/test_event__init__.py
@@ -109,20 +109,10 @@ async def test_update_by_id_pymongo_raises_duplicate_key_error_successful_on_ret
 
 async def test_update_by_id_pymongo_raises_duplicate_key_error_failure_on_retry(app, event):
     with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
-        mock_replace.side_effect = DuplicateKeyError("error_msg")
+        mock_replace.side_effect = [DuplicateKeyError("error after first run"),
+                                    DuplicateKeyError("error after second run")]
 
-        with pytest.raises(APIException,
-                           match=f"Failed to update event data for event_id {event.id}"
-                                 f" due to DuplicateKeyError: error_msg"):
-            await app["db"].event.update_by_id(event.id, event)
-
-
-async def test_update_by_id_pymongo_raises_exception(app, event):
-    with patch.object(app["db"].event.collection, "replace_one", new=CoroutineMock()) as mock_replace:
-        mock_replace.side_effect = Exception("error_msg")
-
-        with pytest.raises(APIException,
-                           match=f"Failed to update event data for event_id {event.id}: error_msg"):
+        with pytest.raises(DuplicateKeyError, match="error after second run"):
             await app["db"].event.update_by_id(event.id, event)
 
 

--- a/ubuild.py
+++ b/ubuild.py
@@ -2,7 +2,10 @@ import subprocess
 from uranium import current_build
 
 current_build.config.set_defaults({
-    "module": "tycho"
+    "module": "tycho",
+    "test_packages": {
+        "asynctest": None,
+    },
 })
 
 current_build.packages.install("orbital-core")


### PR DESCRIPTION
Added support to retry once more on occurrence of `DuplicateKeyError` during mongodb `replace_one` operation.