### PR TITLE
Added DuplicateKeyError exception handling for Bad Request

### DIFF
--- a/tycho/routes/event.py
+++ b/tycho/routes/event.py
@@ -142,10 +142,10 @@ async def put_event(request, event: Event) -> Event:
     """
     try:
         await request.app["db"].event.save(event)
-        if request.app["config"].log_events:
-            LOG.info(json.dumps(event.to_primitive()))
-    except DuplicateKeyError as err:
-        raise APIException(message=f"Failed to add event. Error says: {err}")
+    except DuplicateKeyError:
+        raise APIException(message=f"Error: id '{event.id}' already exists")
+    if request.app["config"].log_events:
+        LOG.info(json.dumps(event.to_primitive()))
     return event
 
 

--- a/tycho/routes/event.py
+++ b/tycho/routes/event.py
@@ -3,6 +3,7 @@ import attr
 import json
 import os
 import logging
+from pymongo.errors import DuplicateKeyError
 from aiohttp import web
 from aiohttp.web import HTTPNotFound
 from aiohttp_transmute import (APIException, add_route, route)
@@ -139,9 +140,12 @@ async def put_event(request, event: Event) -> Event:
     :param event: the event to be stored
     :return: the stored event
     """
-    await request.app["db"].event.save(event)
-    if request.app["config"].log_events:
-        LOG.info(json.dumps(event.to_primitive()))
+    try:
+        await request.app["db"].event.save(event)
+        if request.app["config"].log_events:
+            LOG.info(json.dumps(event.to_primitive()))
+    except DuplicateKeyError as err:
+        raise APIException(message=f"Failed to add event. Error says: {err}")
     return event
 
 

--- a/tycho/tests/routes/test_event.py
+++ b/tycho/tests/routes/test_event.py
@@ -260,7 +260,7 @@ async def test_put_event_with_error(db, event, cli, app):
                              data=json.dumps({"event": event.to_primitive()}))
         assert resp.status == 400
         retrieved_event_json = (await resp.json())
-        assert "Failed to add event. Error says:" in retrieved_event_json["result"]
+        assert "Error: id '5498d53c5f2d60095267a0bb' already exists" == retrieved_event_json["result"]
 
 
 async def test_put_invalid_event_raises_exception(cli):

--- a/tycho/tests/routes/test_event.py
+++ b/tycho/tests/routes/test_event.py
@@ -250,6 +250,19 @@ async def test_put_event(db, event, cli, log, app):
             assert mock_log.assert_not_called
 
 
+async def test_put_event_with_error(db, event, cli, app):
+    with patch("tycho.routes.event.LOG") as mock_log:
+        app["config"].log_events = False
+        event_resp = await cli.put(f'/api/v1/event/', headers={"content-type": "application/json"},
+                                   data=json.dumps({"event": event.to_primitive()}))
+        assert event_resp.status == 200
+        resp = await cli.put(f'/api/v1/event/', headers={"content-type": "application/json"},
+                             data=json.dumps({"event": event.to_primitive()}))
+        assert resp.status == 400
+        retrieved_event_json = (await resp.json())
+        assert "Failed to add event. Error says:" in retrieved_event_json["result"]
+
+
 async def test_put_invalid_event_raises_exception(cli):
     event_json = {'source_id': """
 {


### PR DESCRIPTION
Raised `APIException` when we get `DuplicateKeyError`
while trying to store duplicate event in database.