### PR TITLE
Added support to handle dot in detail_urls' keys

### DIFF
--- a/tycho/db/event/deserialize.py
+++ b/tycho/db/event/deserialize.py
@@ -1,7 +1,6 @@
-from ...models.eventdb import EventDB
-from ...models.event import Event
 from typing import Dict, List
 
+from ...models.event import Event, DOT_CONSTANT, DOT_CONVERTER
 
 _reserved_fields_in_eventdb_tag = {
     "source_id", "parent_id"
@@ -26,7 +25,10 @@ def deserialize_db_event(eventdb: Dict) -> Event:
             new_event["id"] = str(eventdb["_id"])
 
         if "detail_urls" in eventdb:
-            new_event["detail_urls"] = eventdb["detail_urls"]
+            new_event["detail_urls"] = {}
+            for key, value in eventdb["detail_urls"].items():
+                key = key.replace(DOT_CONVERTER, DOT_CONSTANT)
+                new_event["detail_urls"][key] = value
 
         if "description" in eventdb:
             new_event["description"] = eventdb["description"]

--- a/tycho/db/event/serialize.py
+++ b/tycho/db/event/serialize.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from ...models.event import Event
 from typing import Dict, List
+
+from ...models.event import Event, DOT_CONVERTER, DOT_CONSTANT
 
 
 def serialize_to_db_event(event: Event) -> Dict:
@@ -30,9 +31,14 @@ def serialize_to_db_event(event: Event) -> Dict:
         if getattr(event, key) is not None:
             new_event["time"].append(getattr(event, key))
 
-    for key in ["detail_urls", "description"]:
-        if getattr(event, key) is not None:
-            new_event[key] = getattr(event, key)
+    if getattr(event, "description") is not None:
+        new_event["description"] = event.description
+
+    if getattr(event, "detail_urls") is not None:
+        new_event["detail_urls"] = {}
+        for key, value in event.detail_urls.items():
+            key = key.replace(DOT_CONSTANT, DOT_CONVERTER)
+            new_event["detail_urls"][key] = value
 
     new_event["update_time"] = datetime.utcnow()
 

--- a/tycho/models/event.py
+++ b/tycho/models/event.py
@@ -8,6 +8,8 @@ from transmute_core.object_serializers.cattrs_serializer import create_cattrs_co
 
 
 CATTRS_CONVERTER = create_cattrs_converter()
+DOT_CONVERTER = "~dot~"
+DOT_CONSTANT = "."
 
 
 def ensure_value_is_not_empty(instance, attribute, value):

--- a/tycho/tests/db/event/test_deserialize.py
+++ b/tycho/tests/db/event/test_deserialize.py
@@ -112,3 +112,11 @@ def test_deserialize_db_event_detail_urls_exist():
 
 def test_deserialize_db_event_all_fields(event, eventdb):
     assert deserialize_db_event(eventdb.asdict()) == event
+
+
+def test_deserialize_db_event_with_dot_converter_in_detail_urls_key(eventdb):
+    event_db_dict = attr.asdict(eventdb)
+    event_db_dict["detail_urls"] = {"foo~dot~bar": "abcd"}
+    event = deserialize_db_event(event_db_dict)
+    assert event
+    assert event.detail_urls == {"foo.bar": "abcd"}

--- a/tycho/tests/db/event/test_event__init__.py
+++ b/tycho/tests/db/event/test_event__init__.py
@@ -16,6 +16,13 @@ async def test_save_data(app, event):
     assert attr.asdict(result) == attr.asdict(event)
 
 
+async def test_save_data_with_dot_in_detail_urls_key(app, event):
+    event.detail_urls["foo.bar"] = "abcd"
+    await app["db"].event.save(event)
+    result = await app["db"].event.find_one()
+    assert attr.asdict(result) == attr.asdict(event)
+
+
 async def test_find_one_data_exists(app, event):
     await app["db"].event.save(event)
     result = await app["db"].event.find_one()

--- a/tycho/tests/db/event/test_serialize.py
+++ b/tycho/tests/db/event/test_serialize.py
@@ -34,9 +34,9 @@ def test_serialize_to_db_event_empty_event(patch_update_time, update_time):
 
 
 def test_serialize_to_db_event_no_tag_field(patch_update_time, update_time):
-    event_db_dict = serialize_to_db_event(Event(detail_urls="http://xyz"))
+    event_db_dict = serialize_to_db_event(Event(detail_urls={"key": "http://xyz"}))
     assert event_db_dict["tags"] == []
-    assert event_db_dict["detail_urls"] == "http://xyz"
+    assert event_db_dict["detail_urls"] == {"key": "http://xyz"}
     assert event_db_dict["update_time"] == update_time
 
 
@@ -84,8 +84,8 @@ def test_serialize_to_db_time_both_times(patch_update_time, update_time):
 
 
 def test_serialize_to_db_detail_urls_exist(patch_update_time, update_time):
-    event_db_dict = serialize_to_db_event(Event(detail_urls={"http://url"}))
-    assert event_db_dict["detail_urls"] == {"http://url"}
+    event_db_dict = serialize_to_db_event(Event(detail_urls={"key": "http://url"}))
+    assert event_db_dict["detail_urls"] == {"key": "http://url"}
     assert event_db_dict["update_time"] == update_time
 
 
@@ -98,3 +98,9 @@ def test_serialize_to_db_event_all_fields(app, event, eventdb, patch_update_time
     result["tags"] = sorted(result["tags"])
     eventdb.tags = sorted(eventdb.tags)
     assert result == eventdb.asdict()
+
+
+def test_serialize_to_db_event_with_dot_in_detail_urls_key(event):
+    event.detail_urls["foo.bar"] = "abcd"
+    result = serialize_to_db_event(event)
+    assert result["detail_urls"]["foo~dot~bar"] == "abcd"


### PR DESCRIPTION
MongoDB doesn't support keys with a dot in them.
So, for the keys in detail_urls, we will be converting the dot before storing it into DB and will revert it on retrieving it from DB.
The only impact is the way we store-retrieve the data in DB. The remaining functionality remains the same.