### PR TITLE
Added support for database authentication

### DIFF
--- a/tycho/db/connection.py
+++ b/tycho/db/connection.py
@@ -21,14 +21,19 @@ def get_db(db_config):
     """
     creates connection with dabatase and gets db object to connect.
     """
-    connection = motor.motor_asyncio.AsyncIOMotorClient(
-        host=db_config.uri,
-        # secondarypreferred has proved to be a good practice,
-        # as it enabled minimal contention on the node that should
-        # be critical and handle writes. Oftentimes delay of event
-        # propagation is in the milliseconds.
-        readPreference="secondaryPreferred",
-    )
+    # secondarypreferred has proved to be a good practice,
+    # as it enabled minimal contention on the node that should
+    # be critical and handle writes. Oftentimes delay of event
+    # propagation is in the milliseconds.
+    connection_config = {
+        "host": db_config.uri,
+        "readPreference": "secondaryPreferred",
+    }
+    if db_config.username:
+        connection_config["username"] = db_config.username
+    if db_config.password:
+        connection_config["password"] = db_config.password
+    connection = motor.motor_asyncio.AsyncIOMotorClient(**connection_config)
     db = connection[db_config.db_name]
     return db
 

--- a/tycho/db/connection.py
+++ b/tycho/db/connection.py
@@ -21,19 +21,12 @@ def get_db(db_config):
     """
     creates connection with dabatase and gets db object to connect.
     """
-    # secondarypreferred has proved to be a good practice,
-    # as it enabled minimal contention on the node that should
-    # be critical and handle writes. Oftentimes delay of event
-    # propagation is in the milliseconds.
-    connection_config = {
-        "host": db_config.uri,
-        "readPreference": "secondaryPreferred",
-    }
-    if db_config.username:
-        connection_config["username"] = db_config.username
-    if db_config.password:
-        connection_config["password"] = db_config.password
-    connection = motor.motor_asyncio.AsyncIOMotorClient(**connection_config)
+    connection = motor.motor_asyncio.AsyncIOMotorClient(
+        host=db_config.uri,
+        readPreference=db_config.read_preference,
+        username=db_config.username,
+        password=db_config.password,
+    )
     db = connection[db_config.db_name]
     return db
 

--- a/tycho/models/config.py
+++ b/tycho/models/config.py
@@ -6,6 +6,7 @@ from schematics.types.compound import ModelType
 class Mongo(Model):
     uri = StringType(required=True)
     db_name = StringType(required=True)
+    read_preference = StringType(required=False, default="secondaryPreferred")
     username = StringType(required=False)
     password = StringType(required=False)
 

--- a/tycho/models/config.py
+++ b/tycho/models/config.py
@@ -6,6 +6,8 @@ from schematics.types.compound import ModelType
 class Mongo(Model):
     uri = StringType(required=True)
     db_name = StringType(required=True)
+    username = StringType(required=False)
+    password = StringType(required=False)
 
 
 class application(Model):


### PR DESCRIPTION
Currently the only way to supply database credentials is by embedding them in the MongoDB URI string; however, pymongo also supports supplying the username and password as attributes to the connection. This is preferable since it separates secrets from normal configuration items. 