### PR TITLE
fixed issue #14: add default docs directory so service starts cleanly

### DIFF
--- a/tycho/docs/index.html
+++ b/tycho/docs/index.html
@@ -1,0 +1,7 @@
+<html>
+<script>
+window.onload = function() {
+    location.href = "https://tycho.readthedocs.io/en/latest/";
+}
+</script>
+</html>


### PR DESCRIPTION
The travis CI build will generate and overwrite the docs directory, so this is only used when including the module directly from github.