### PR TITLE
Fix issue #14: add default docs directory so service starts cleanly

### DIFF
--- a/tycho/docs/index.html
+++ b/tycho/docs/index.html
@@ -1,0 +1,7 @@
+<html>
+<script>
+window.onload = function() {
+    location.href = "https://tycho.readthedocs.io/en/latest/";
+}
+</script>
+</html>


### PR DESCRIPTION
Fix issue #14 

Added a default `docs` directory containing a redirect to the public docs. This allows the service to run when included as a git dependency. When the Uranium build runs, it will replace the default docs with the generated docs. (see: https://github.com/zillow/tycho/blob/master/ubuild.py#L60-L61)