### PR TITLE
Increase tag max_length from 100 to 200

### DIFF
--- a/tycho/tests/conftest.py
+++ b/tycho/tests/conftest.py
@@ -51,7 +51,7 @@ def db(loop, config):
     asyncio.set_event_loop(loop)
     _db = init_db(config.mongo)
     yield _db
-    if _db:
+    if _db is not None:
         loop.run_until_complete(_db.command("dropDatabase"))
 
 

--- a/tycho/tests/models/test_model_eventdb.py
+++ b/tycho/tests/models/test_model_eventdb.py
@@ -5,7 +5,7 @@ from tycho.models.eventdb import EventDB
 from schematics.contrib.mongo import ObjectIdType
 from schematics.exceptions import DataError
 from schematics.models import Model
-
+from cattrs.errors import ClassValidationError
 from tycho.models.event import CATTRS_CONVERTER
 
 
@@ -42,14 +42,14 @@ def test_eventdb_no_field_present():
     doc = {}
     # when no illegal value present.
     # below initialization won't raise exception.
-    with pytest.raises(TypeError):
+    with pytest.raises(ClassValidationError):
         CATTRS_CONVERTER.structure(doc, EventDB)
 
 
 def test_eventdb_required_fields_not_present():
     doc = {"detail_urls": {"graphite": "http://graphite",
                            "concrete": "http://concrete"}}
-    with pytest.raises(TypeError):
+    with pytest.raises(ClassValidationError):
         CATTRS_CONVERTER.structure(doc, EventDB)
 
 


### PR DESCRIPTION
- Increased the allowed maximum length of tag attribute in event model to 200
- Updated field validator function in event model to take customize number of maximum allowed characters
- Fixed a few unit tests